### PR TITLE
add default option for location

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -4,13 +4,17 @@ from docxtpl import DocxTemplate
 
 def CoverLetter(companyName, id, location, positionName, date):
     doc = DocxTemplate("letter.docx")
+
+    if(location == ""): 
+        location = "Ottawa, Ontario"
+
     context = {
         'date': date,
         'company_name': companyName,
         'jobId': id,
         'location': location,
         'positionName': positionName
-
+        
     }
     doc.render(context)
     return doc


### PR DESCRIPTION
I added the default location of "Ottawa, Ontario".
If users enter a empty string for location, the location will automatically be set to Ottawa, Ontario.